### PR TITLE
Add global Registry. Closes #2

### DIFF
--- a/lib/Registry.js
+++ b/lib/Registry.js
@@ -1,0 +1,37 @@
+var _ = require('lodash');
+
+var Resource = require('./Resource');
+
+function Registry() {
+	this._resources = {};
+}
+
+Registry.prototype.get = function(name) {
+	if (name) {
+		return this._resources[name];
+	} else {
+		return _.keys(this._resources);
+	}
+}
+
+Registry.prototype.add = function(name, resource) {
+	if (!this._resources[name] && resource instanceof Resource) {
+		this._resources[name] = resource;
+	}
+};
+
+Registry.prototype.remove = function(name) {
+	if (this._resources[name]) {
+		delete this._resources[name];
+	}
+}
+var instance;
+
+function getInstance() {
+	if (!instance) {
+		instance = new Registry();
+	}
+	return instance;
+}
+
+module.exports = exports = getInstance();

--- a/lib/accessors/Ref.js
+++ b/lib/accessors/Ref.js
@@ -6,12 +6,13 @@ var mongoose = require('mongoose');
 var ObjectId = mongoose.Types.ObjectId;
 
 var Accessor = require('../Accessor');
+var Registry = require('../Registry');
 var ResourceNotFound = require('../errors/ResourceNotFound');
 var InvalidFieldValue = require('../errors/InvalidFieldValue');
 
-function Ref(resource, thisPath, opts) {
+function Ref(resourceName, thisPath, opts) {
 	opts = opts || {};
-	this._resource = resource;
+	this._resourceName = resourceName;
 	this._thisPath = thisPath;
 	this._links = opts.links;
 	this._meta = opts.meta;
@@ -27,7 +28,7 @@ Ref.prototype.serialize = function(field, transaction, object, callback) {
 	var self = this;
 	var id = _.get(object, this._thisPath);
 	if (_.isUndefined(id)) return callback(null);
-	var resource = this._resource;
+	var resource = Registry.get(this._resourceName);
 	var response = transaction.response;
 	var resview = resource.view(transaction);
 	resview.findOne({ _id: id }, function(err, linked) {
@@ -48,7 +49,7 @@ Ref.prototype.serialize = function(field, transaction, object, callback) {
 
 Ref.prototype.deserialize = function(field, transaction, resdata, object, callback) {
 	if (!_.isPlainObject(resdata)) return callback(new InvalidFieldValue(field, resdata));
-	if (resdata.type !== this._resource.type || !ObjectId.isValid(resdata.id))
+	if (resdata.type !== Registry.get(this._resourceName).type || !ObjectId.isValid(resdata.id))
 		return callback(new InvalidFieldValue(field, resdata));
 	_.set(object, this._thisPath, new ObjectId(resdata.id));
 	callback(null, object);

--- a/lib/accessors/Refs.js
+++ b/lib/accessors/Refs.js
@@ -6,12 +6,13 @@ var mongoose = require('mongoose');
 var ObjectId = mongoose.Types.ObjectId;
 
 var Accessor = require('../Accessor');
+var Registry = require('../Registry');
 var ResourceNotFound = require('../errors/ResourceNotFound');
 var InvalidFieldValue = require('../errors/InvalidFieldValue');
 
-function Refs(resource, thisPath, opts) {
+function Refs(resourceName, thisPath, opts) {
 	opts = opts || {};
-	this._resource = resource;
+	this._resourceName = resourceName;
 	this._thisPath = thisPath;
 }
 
@@ -25,7 +26,7 @@ Refs.prototype.serialize = function(field, transaction, object, callback) {
 	var self = this;
 	var ids = _.get(object, this._thisPath);
 	if (_.isUndefined(ids)) return callback(null);
-	var resource = this._resource;
+	var resource = Registry.get(this._resourceName);
 	var response = transaction.response;
 	var resview = resource.view(transaction);
 	var isIncluded = transaction.transform(field.resource, 'include', field.name, true);
@@ -53,7 +54,7 @@ Refs.prototype.deserialize = function(field, transaction, resdata, object, callb
 	var links = [];
 	_.set(object, this._thisPath, links);
 	_.each(resdata, function(link, index) {
-		if (link.type !== self._resource.type || !ObjectId.isValid(link.id)) {
+		if (link.type !== Registry.get(self._resourceName).type || !ObjectId.isValid(link.id)) {
 			var opts = { meta: { index: index }};
 			var err = new InvalidFieldValue(field, resdata, opts);
 			return callback(err);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 var _ = require('lodash');
 
 module.exports = exports = {
+	Registry: require('./Registry'),
 	Link: require('./Link'),
 	Field: require('./Field'),
 	Accessor: require('./Accessor'),


### PR DESCRIPTION
Solves #2 by creating a global (singleton) `Registry` for `Resource`s &mdash; something like how mongoose `Schema`s must be registered to `Model`s. The changes are minimal but breaking.

#### Changes
1. When defining a `Resource` containing `Ref` or `Refs`, a name must be used instead of a direct reference to the linked resource.
2. `Resource`s must be registered by calling `Registry.add(name, resource)`.

#### Benefits
1. Allows for circular references (as in #2).
2. Allows for `Resource`s to be defined in separate files that do not need to `require` each other.
3. Makes `Resource`s available more easily: `Registry.get()` returns an array with a list of all the registered `Resource`s; `Registry.get(name)` returns a reference to the `Resource` registered with `name`.

#### Example (the one in #2)
```js
/**
 * models/thread.js
 */

import mongoose from 'mongoose';

const threadSchema = new mongoose.Schema({
  title: String,
  posts: [{
    type: mongoose.Schema.ObjectId,
    ref: 'Post'
  }]
});

export default mongoose.model('Thread', threadSchema);

/**
 * models/post.js
 */

import mongoose from 'mongoose';

const postSchema = new mongoose.Schema({
  body: String,
  thread: {
    type: mongoose.Schema.ObjectId,
    ref: 'Thread'
  }
});

export default mongoose.model('Post', postSchema);

/**
 * models/index.js
 */

import Thread from './thread';
import Post from './post';

export default { Thread, Post };

/**
 * resources/thread.js
 */

import { Registry, Resource, Property, Refs } from 'jsonapify';
import { Thread } from '../models';

const threadResource = new Resource(Thread, {
  type: 'threads',
  id: new Property('_id'),
  attributes: {
    title: new Property('title')
  },
  relationships: {
    posts: new Refs('Post', 'posts')
  }
});

Registry.add('Thread', threadResource);

export default threadResource;

/**
 * resources/post.js
 */

import { Registry, Resource, Property, Ref } from 'jsonapify';
import { Post } from '../models';

const postResource = new Resource(Post, {
  type: 'posts',
  id: new Property('_id'),
  attributes: {
    body: new Property('body')
  },
  relationships: {
    thread: new Ref('Thread', 'thread');
  }
});

Registry.add('Post', postResource);

export default postResource;

/**
 * resources/index.js
 */

// Not really needed, since they are on the `Registry` singleton...

import Thread from './thread';
import Post from './post';

export default { Thread, Post };
```

#### Tests and docs

Existing tests pass (with the appropriate modifications). I have not written any for `Registry` though. I also haven't touched the README file.