### PR TITLE
Remove `nullable`

### DIFF
--- a/lib/Field.js
+++ b/lib/Field.js
@@ -8,14 +8,12 @@ function Field(resource, name, value, opts) {
 	opts = _.defaults({}, opts, {
 		readable: true,
 		writable: true,
-		nullable: false,
 	});
 	this._name = name;
 	this._resource = resource;
 	this._accessor = toAccessor(value);
 	this._readable = opts.readable;
 	this._writable = opts.writable;
-	this._nullable = opts.nullable;
 }
 
 Object.defineProperties(Field.prototype, {
@@ -23,7 +21,6 @@ Object.defineProperties(Field.prototype, {
 	resource: { get: function() { return this._resource }},
 	readable: { get: function() { return this._readable }},
 	writable: { get: function() { return this._writable }},
-	nullable: { get: function() { return this._nullable }},
 });
 
 Field.prototype.accessProperty = function(callback) {
@@ -35,16 +32,12 @@ Field.prototype.serialize = function(transaction, object, callback) {
 	if (!this._readable) return callback(null);
 	this._accessor.serialize(this, transaction, object, function(err, value) {
 		if (err) return callback(err);
-		if (_.isUndefined(value) && !self._nullable)
-			return callback(new InvalidFieldValue(self, undefined));
 		return callback(null, value);
 	});
 };
 
 Field.prototype.deserialize = function(transaction, resdata, object, callback) {
 	if (!this._writable) return callback(null, object);
-	if (_.isUndefined(resdata) && !this._nullable)
-		return callback(new InvalidFieldValue(this, undefined));
 	this._accessor.deserialize(this, transaction, resdata, object, callback);
 };
 

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -52,7 +52,7 @@ function extractFields(self, object, fields) {
 function isFieldDescriptor(object) {
 	if (!_.isPlainObject(object)) return false;
 	if (!_.has(object, 'value')) return false;
-	var allowedKeys = ['value','readable','writable','nullable'];
+	var allowedKeys = ['value','readable','writable'];
 	return _.all(object, function(value, key) {
 		return _.includes(allowedKeys, key);
 	});

--- a/lib/ResourceView.js
+++ b/lib/ResourceView.js
@@ -119,7 +119,11 @@ ResourceView.prototype.deserialize = function(resdata, object, callback) {
 	var self = this;
 	async.each(this._writableFields, function(field, next) {
 		var value = _.get(resdata, field.name);
-		field.deserialize(self._transaction, value, object, next);
+		if (!_.isUndefined(value)) {
+			field.deserialize(self._transaction, value, object, next);
+		} else {
+			next();
+		}
 	}, function(err) {
 		err ? callback(err) : callback(null, object);
 	});

--- a/test/Field.js
+++ b/test/Field.js
@@ -12,7 +12,7 @@ describe('Field', function() {
 	before(function() {
 		resource = new Resource({ type: 'test' });
 	});
-	
+
 	describe('#name', function() {
 		it('returns the field name', function() {
 			var expected = 'name';
@@ -20,50 +20,38 @@ describe('Field', function() {
 			expect(field).to.have.property('name', expected);
 		});
 	});
-	
+
 	describe('#resource', function() {
 		it('returns the resource the field is associated with', function() {
 			var field = new Field(resource, 'name', null);
 			expect(field).to.have.property('resource', resource);
 		});
 	});
-	
+
 	describe('#readable', function() {
 		it('returns true if field is readable', function() {
 			var field = new Field(resource, 'name', null, { readable: true });
 			expect(field).to.have.property('readable', true);
 		});
-		
+
 		it('returns false if field is not readable', function() {
 			var field = new Field(resource, 'name', null, { readable: false });
 			expect(field).to.have.property('readable', false);
 		});
 	});
-	
+
 	describe('#writable', function() {
 		it('returns true if field is writable', function() {
 			var field = new Field(resource, 'name', null, { writable: true });
 			expect(field).to.have.property('writable', true);
 		});
-		
+
 		it('returns false if field is not writable', function() {
 			var field = new Field(resource, 'name', null, { writable: false });
 			expect(field).to.have.property('writable', false);
 		});
 	});
-	
-	describe('#nullable', function() {
-		it('returns true if field is nullable', function() {
-			var field = new Field(resource, 'name', null, { nullable: true });
-			expect(field).to.have.property('nullable', true);
-		});
-		
-		it('returns false if field is not nullable', function() {
-			var field = new Field(resource, 'name', null, { nullable: false });
-			expect(field).to.have.property('nullable', false);
-		});
-	});
-	
+
 	describe('#accessProperty', function() {
 		it('invokes accessProperty method on accessor', function() {
 			var callback = sinon.spy();
@@ -75,14 +63,14 @@ describe('Field', function() {
 			expect(callback).to.have.been.calledWith('property');
 		});
 	});
-	
+
 	describe('#serialize', function() {
 		var transaction, object;
 		beforeEach(function() {
 			object = {};
 			transaction = common.createTransaction(resource);
 		});
-		
+
 		it('gives constant value in callback', function(done) {
 			var expected = 'value';
 			var field = new Field(resource, 'name', expected);
@@ -92,7 +80,7 @@ describe('Field', function() {
 				done();
 			});
 		});
-		
+
 		it('invokes serialize method on accessor', function(done) {
 			var expected = 'value';
 			var accessor = common.createAccessor();
@@ -105,7 +93,7 @@ describe('Field', function() {
 				done();
 			});
 		});
-		
+
 		it('gives undefined if field is not readable', function(done) {
 			var field = new Field(resource, 'name', 'value', { readable: false });
 			field.serialize(transaction, object, function(err, value) {
@@ -115,14 +103,14 @@ describe('Field', function() {
 			});
 		});
 	});
-	
+
 	describe('#deserialize', function() {
 		var transaction, object;
 		beforeEach(function() {
 			transaction = common.createTransaction(resource);
 			object = {};
 		});
-		
+
 		it('invokes callback with output object', function(done) {
 			var expected = 'value';
 			var field = new Field(resource, 'name', expected);
@@ -133,7 +121,7 @@ describe('Field', function() {
 				done();
 			});
 		});
-		
+
 		it('does not change object if field is not writable', function(done) {
 			var expected = 'value';
 			var field = new Field(resource, 'name', expected, { writable: false });
@@ -144,8 +132,8 @@ describe('Field', function() {
 				done();
 			});
 		});
-		
-		
+
+
 		it('invokes deserialize method on accessor', function(done) {
 			var expected = 'value';
 			var accessor = common.createAccessor();
@@ -158,19 +146,10 @@ describe('Field', function() {
 				done();
 			});
 		});
-		
+
 		it('gives an error if not expected field value', function(done) {
 			var field = new Field(resource, 'name', 'value');
 			field.deserialize(transaction, 'invalid', object, function(err, output) {
-				expect(err).to.exist;
-				expect(object).to.be.empty;
-				done();
-			});
-		});
-		
-		it('gives an error if value is undefined for not nullable field', function(done) {
-			var field = new Field(resource, 'name', 'value');
-			field.deserialize(transaction, undefined, object, function(err, output) {
 				expect(err).to.exist;
 				expect(object).to.be.empty;
 				done();

--- a/test/filters/filter.js
+++ b/test/filters/filter.js
@@ -27,14 +27,8 @@ describe('filter', function() {
 
 	beforeEach(function() {
 		resource = new Resource(model, {
-			number: {
-				value: new Property('number'),
-				nullable: true,
-			},
-			string: {
-				value: new Property('string'),
-				nullable: true,
-			},
+			number: new Property('number'),
+			string: new Property('string'),
 		});
 		var res = httpMocks.createResponse();
 		var response = new Response(res);

--- a/test/middleware/modify.js
+++ b/test/middleware/modify.js
@@ -21,7 +21,7 @@ describe('modify', function() {
 			done();
 		});
 	});
-	
+
 	beforeEach(function() {
 		accessors = {
 			foo: new jsonapify.Accessor,
@@ -30,28 +30,22 @@ describe('modify', function() {
 		};
 		resource = new Resource(model, {
 			type: 'test',
-			field: {
-				value: accessors.field,
-				nullable: true,
-			},
-			output: {
-				value: accessors.output,
-				nullable: true,
-			},
+			field: accessors.field,
+			output: accessors.output,
 		});
 		Registry.add('ModifyResource', resource);
 		res = httpMocks.createResponse();
 	});
-	
+
 	afterEach(function(done) {
 		Registry.remove('ModifyResource');
 		mongoose.connection.db.dropDatabase(done);
 	});
-	
+
 	after(function(done) {
 		mongoose.disconnect(done);
 	});
-	
+
 	describe('add', function() {
 		it('inserts element in array at index', function(done) {
 			model.create({}, function(err, object) {
@@ -78,7 +72,7 @@ describe('modify', function() {
 				});
 			});
 		});
-		
+
 		it('adds new property to object', function(done) {
 			model.create({}, function(err, object) {
 				if (err) return done(err);
@@ -104,7 +98,7 @@ describe('modify', function() {
 				});
 			});
 		});
-		
+
 		it('replaces existing object property', function(done) {
 			model.create({}, function(err, object) {
 				if (err) return done(err);
@@ -131,7 +125,7 @@ describe('modify', function() {
 			});
 		});
 	});
-	
+
 	describe('remove', function() {
 		it('removes the value at the target location', function(done) {
 			model.create({}, function(err, object) {
@@ -156,7 +150,7 @@ describe('modify', function() {
 				});
 			});
 		});
-		
+
 		it('gives an error if the value does not exist', function(done) {
 			model.create({}, function(err, object) {
 				if (err) return done(err);
@@ -179,7 +173,7 @@ describe('modify', function() {
 			});
 		});
 	});
-	
+
 	describe('replace', function() {
 		it('replaces the value at the target location', function(done) {
 			model.create({}, function(err, object) {
@@ -206,7 +200,7 @@ describe('modify', function() {
 				});
 			});
 		});
-		
+
 		it('gives an error if the value does not exist', function(done) {
 			model.create({}, function(err, object) {
 				if (err) return done(err);
@@ -229,7 +223,7 @@ describe('modify', function() {
 			});
 		});
 	});
-	
+
 	describe('move', function() {
 		it('removes the value from path and adds it to the target location', function(done) {
 			model.create({}, function(err, object) {
@@ -257,7 +251,7 @@ describe('modify', function() {
 				});
 			});
 		});
-		
+
 		it('gives an error if the value does not exist', function(done) {
 			model.create({}, function(err, object) {
 				if (err) return done(err);
@@ -281,7 +275,7 @@ describe('modify', function() {
 			});
 		});
 	});
-	
+
 	describe('copy', function() {
 		it('copies the value from path to the target location', function(done) {
 			model.create({}, function(err, object) {
@@ -310,7 +304,7 @@ describe('modify', function() {
 				});
 			});
 		});
-		
+
 		it('gives an error if the value does not exist', function(done) {
 			model.create({}, function(err, object) {
 				if (err) return done(err);
@@ -334,7 +328,7 @@ describe('modify', function() {
 			});
 		});
 	});
-	
+
 	describe('test', function() {
 		it('tests that value at path is equal to value', function(done) {
 			model.create({}, function(err, object) {
@@ -361,7 +355,7 @@ describe('modify', function() {
 				});
 			});
 		});
-		
+
 		it('gives an error if values do not match', function(done) {
 			model.create({}, function(err, object) {
 				if (err) return done(err);
@@ -384,7 +378,7 @@ describe('modify', function() {
 				});
 			});
 		});
-		
+
 		it('gives an error if the value does not exist', function(done) {
 			model.create({}, function(err, object) {
 				if (err) return done(err);


### PR DESCRIPTION
Exactly as I outlined in #4.

With a resource definition like
```js
module.exports = function (mongoose, jsonapify) {
  const resource = new jsonapify.Resource(mongoose.model('User'), {
    type: 'users',
    id: new jsonapify.Property('_id'),
    attributes: {
      username: new jsonapify.Property('username'),
      fullname: new jsonapify.Property('fullname'),
      displayFullname: new jsonapify.Property('displayFullname'),
      email: new jsonapify.Property('email'),
      password: {
        value: new jsonapify.Property('password'),
        readable: false
      },
      createdAt: new jsonapify.Property('createdAt'),
      modifiedAt: new jsonapify.Property('modifiedAt'),
      deleted: new jsonapify.Property('deleted'),
      permissions: new jsonapify.Property('permissions')
    },
    links: {
      self: {
        value: new jsonapify.Template('/api/users/${username}'),
        writable: false
      }
    }
  });

  jsonapify.Registry.add('User', resource);

  return resource;
};
```
one can now make a POST request with a body like
```js
{
  "data": {
    "type": "users",
    "attributes": {
      "username": "anothertest",
      "fullname": "Another Test",
      "displayFullname": false,
      "password": "blah",
      "email": "test2@example.com",
      "permissions": [
        "self",
        "moderate",
        "admin"
      ]
    }
  }
}
```
and get back a 201 Created with data
```js
{
  "links": {
    "self": "/api/users"
  },
  "data": {
    "type": "users",
    "id": "55edf576b59f5c4997879849",
    "attributes": {
      "username": "anothertest",
      "fullname": "Another Test",
      "displayFullname": false,
      "email": "test2@example.com",
      "createdAt": "2015-09-07T20:37:10.220Z",
      "modifiedAt": "2015-09-07T20:37:10.220Z",
      "deleted": false,
      "permissions": [
        "self",
        "moderate",
        "admin"
      ]
    },
    "links": {
      "self": "/api/users/anothertest"
    }
  },
  "jsonapi": {
    "version": "1.0"
  }
}
```
instead of `jsonapify` complaining that `id`, `createdAt` and `modifiedAt` are invalid field values (I have the last two with a `default: Date.now()` in the `mongoose` model definition).

Making a POST request that violates the `mongoose` model validation returns, appropriately, an error. For example, making the request above a second time yields a 500 Internal Server Error (**which should probably be changed to a 409 Conflict**) with data
```js
{
  "links": {
    "self": "/api/users"
  },
  "errors": [
    {
      "detail": "E11000 duplicate key error index: c3902.users.$username_1 dup key: { : \"anothertest\" }"
    }
  ],
  "jsonapi": {
    "version": "1.0"
  }
}
```