### PR TITLE
fix pagination links

### DIFF
--- a/lib/filters/common.js
+++ b/lib/filters/common.js
@@ -1,4 +1,5 @@
 var url = require('url');
+var qs = require('qs');
 
 var _ = require('lodash');
 
@@ -17,10 +18,11 @@ function createFilter(queryParse, handler) {
 	};
 }
 
-function modifyQuery(uri, name, query) {
+function modifyQuery(uri, query) {
 	var info = url.parse(uri);
-	info.search = undefined;
-	_.assign(info.query, query);
+	var queryObj = qs.parse(info.query);
+	queryObj = _.merge(queryObj, query);
+	info.search = '?' + qs.stringify(queryObj, { encode: false });
 	return url.format(info);
 }
 

--- a/lib/filters/paginateOffset.js
+++ b/lib/filters/paginateOffset.js
@@ -15,14 +15,14 @@ function paginate() {
 			var response = transaction.response;
 			var count = response.meta['count'];
 			response.links['first'] = common.modifyQuery(selfLink, { page: {
-				offset: 0, limit: pageLimit
+				offset: 0
 			}});
 			response.links['last'] = common.modifyQuery(selfLink, { page: {
-				offset: count - pageLimit, limit: pageLimit
+				offset: count - pageLimit
 			}});
 			if (pageOffset > 0) {
 				response.links['prev'] = common.modifyQuery(selfLink, { page: {
-					offset: pageOffset - pageLimit
+					offset: (pageOffset - pageLimit < 0) ? 0 : pageOffset - pageLimit
 				}});
 			}
 			if ((pageOffset + pageLimit) < count) {
@@ -42,4 +42,3 @@ function queryParser(req, callback) {
 }
 
 module.exports = paginate;
-

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "istanbul": "^0.4.0",
     "mocha": "^2.3.3",
     "node-mocks-http": "^1.5.0",
+    "qs": "^6.1.0",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0"
   },
@@ -41,6 +42,7 @@
     "glob2re": "^1.0.1",
     "jsonpatch": "^2.0.0",
     "lodash": "^3.10.1",
-    "mongoose": "^4.2.3"
+    "mongoose": "^4.2.3",
+    "qs": "^6.1.0"
   }
 }

--- a/test/filters/paginateOffset.js
+++ b/test/filters/paginateOffset.js
@@ -4,6 +4,7 @@ var async = require('async');
 chai.use(require('sinon-chai'));
 var mongoose = require('mongoose');
 var httpMocks = require('node-mocks-http');
+var qs = require('qs');
 var expect = chai.expect;
 
 var common = require('../common');
@@ -36,7 +37,6 @@ describe('paginateOffset', function() {
 			var res = httpMocks.createResponse();
 			var response = new Response(res);
 			transaction = new Transaction(resource, response);
-			jsonapify.filters.paginateOffset()(transaction);
 			done();
 		});
 	});
@@ -50,9 +50,12 @@ describe('paginateOffset', function() {
 	});
 
 	it('paginates resources and adds pagination links', function(done) {
+		var query = { page: { offset: 1, limit: 2 }};
 		var req = httpMocks.createRequest({
-			query: { page: { offset: 1, limit: 2 }}
+			url: '/test?' + qs.stringify(query),
+			query: query
 		});
+		jsonapify.filters.paginateOffset()(transaction, req);
 		transaction.notify(resource, 'start', req);
 		var resview = resource.view(transaction);
 		resview.findMany({}, function(err, results) {
@@ -61,18 +64,21 @@ describe('paginateOffset', function() {
 			var response = transaction.response;
 			response.meta['count'] = objects.length;
 			transaction.notify(resource, 'end');
-			expect(response).to.have.deep.property('links.first');
-			expect(response).to.have.deep.property('links.last');
-			expect(response).to.have.deep.property('links.prev');
-			expect(response).to.have.deep.property('links.next');
+			expect(response).to.have.deep.property('links.first', '/test?page[offset]=0&page[limit]=2');
+			expect(response).to.have.deep.property('links.last', '/test?page[offset]=3&page[limit]=2');
+			expect(response).to.have.deep.property('links.prev', '/test?page[offset]=0&page[limit]=2');
+			expect(response).to.have.deep.property('links.next', '/test?page[offset]=3&page[limit]=2');
 			done();
 		});
 	});
 
 	it('omits prev link if first page selected', function(done) {
+		var query = { page: { offset: 0, limit: 2 }};
 		var req = httpMocks.createRequest({
-			query: { page: { offset: 0, limit: 2 }}
+			url: '/test?' + qs.stringify(query),
+			query: query
 		});
+		jsonapify.filters.paginateOffset()(transaction, req);
 		transaction.notify(resource, 'start', req);
 		var resview = resource.view(transaction);
 		resview.findMany({}, function(err, results) {
@@ -81,18 +87,21 @@ describe('paginateOffset', function() {
 			var response = transaction.response;
 			response.meta['count'] = objects.length;
 			transaction.notify(resource, 'end');
-			expect(response).to.have.deep.property('links.first');
-			expect(response).to.have.deep.property('links.last');
+			expect(response).to.have.deep.property('links.first', '/test?page[offset]=0&page[limit]=2');
+			expect(response).to.have.deep.property('links.last', '/test?page[offset]=3&page[limit]=2');
 			expect(response).to.not.have.deep.property('links.prev');
-			expect(response).to.have.deep.property('links.next');
+			expect(response).to.have.deep.property('links.next', '/test?page[offset]=2&page[limit]=2');
 			done();
 		});
 	});
 
 	it('omits next link if last page selected', function(done) {
+		var query = { page: { offset: objects.length - 2, limit: 2 }};
 		var req = httpMocks.createRequest({
-			query: { page: { offset: objects.length - 2, limit: 2 }}
+			url: '/test?' + qs.stringify(query),
+			query: query
 		});
+		jsonapify.filters.paginateOffset()(transaction, req);
 		transaction.notify(resource, 'start', req);
 		var resview = resource.view(transaction);
 		resview.findMany({}, function(err, results) {
@@ -101,9 +110,9 @@ describe('paginateOffset', function() {
 			var response = transaction.response;
 			response.meta['count'] = objects.length;
 			transaction.notify(resource, 'end');
-			expect(response).to.have.deep.property('links.first');
-			expect(response).to.have.deep.property('links.last');
-			expect(response).to.have.deep.property('links.prev');
+			expect(response).to.have.deep.property('links.first', '/test?page[offset]=0&page[limit]=2');
+			expect(response).to.have.deep.property('links.last', '/test?page[offset]=3&page[limit]=2');
+			expect(response).to.have.deep.property('links.prev', '/test?page[offset]=1&page[limit]=2');
 			expect(response).to.not.have.deep.property('links.next');
 			done();
 		});


### PR DESCRIPTION
The method `modifyQuery` doesn't generate correct pagination links, and tests are not checking generated links.
